### PR TITLE
Add salary field to job prospects and update forms and display

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { insertProspectSchema, STATUSES, INTEREST_LEVELS, formatSalary, parseSalaryToStorageFormat } from "@shared/schema";
 import type { InsertProspect } from "@shared/schema";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
@@ -36,13 +36,18 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       jobUrl: "",
       status: "Bookmarked",
       interestLevel: "Medium",
+      salary: "",
       notes: "",
     },
   });
 
   const mutation = useMutation({
     mutationFn: async (data: InsertProspect) => {
-      await apiRequest("POST", "/api/prospects", data);
+      const payload = {
+        ...data,
+        salary: data.salary ? parseSalaryToStorageFormat(data.salary) : null,
+      };
+      await apiRequest("POST", "/api/prospects", payload);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/prospects"] });
@@ -156,6 +161,29 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. $100,000"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => {
+                    const formatted = formatSalary(e.target.value);
+                    field.onChange(formatted);
+                  }}
+                  data-testid="input-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { insertProspectSchema, STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { insertProspectSchema, STATUSES, INTEREST_LEVELS, formatSalary, parseSalaryToStorageFormat } from "@shared/schema";
 import type { InsertProspect, Prospect } from "@shared/schema";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
@@ -41,13 +41,18 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       jobUrl: prospect.jobUrl ?? "",
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
+      salary: prospect.salary ?? "",
       notes: prospect.notes ?? "",
     },
   });
 
   const mutation = useMutation({
     mutationFn: async (data: InsertProspect) => {
-      await apiRequest("PATCH", `/api/prospects/${prospect.id}`, data);
+      const payload = {
+        ...data,
+        salary: data.salary ? parseSalaryToStorageFormat(data.salary) : null,
+      };
+      await apiRequest("PATCH", `/api/prospects/${prospect.id}`, payload);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/prospects"] });
@@ -160,6 +165,29 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. $100,000"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => {
+                    const formatted = formatSalary(e.target.value);
+                    field.onChange(formatted);
+                  }}
+                  data-testid="input-edit-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -106,6 +106,13 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
         </div>
+
+        {prospect.salary && (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400" data-testid={`text-salary-${prospect.id}`}>
+            <DollarSign className="w-3 h-3" />
+            {prospect.salary.replace(/^\$/, "")}
+          </span>
+        )}
 
         {prospect.jobUrl && (
           <a

--- a/replit.md
+++ b/replit.md
@@ -30,7 +30,7 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -1,4 +1,5 @@
 import { validateProspect } from "../prospect-helpers";
+import { formatSalary, parseSalaryToStorageFormat } from "@shared/schema";
 
 describe("prospect creation validation", () => {
   test("rejects a blank company name", () => {
@@ -19,5 +20,111 @@ describe("prospect creation validation", () => {
 
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Role title is required");
+  });
+
+  test("accepts a valid prospect with salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: "$120,000",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a prospect with no salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a prospect with null salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts a prospect with empty string salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: "",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects salary with no digits", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: "$,,",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must contain at least one digit");
+  });
+});
+
+describe("formatSalary", () => {
+  test("formats plain digits with $ and commas", () => {
+    expect(formatSalary("100000")).toBe("$100,000");
+  });
+
+  test("formats a number with existing $ and commas", () => {
+    expect(formatSalary("$100,000")).toBe("$100,000");
+  });
+
+  test("handles small numbers without commas", () => {
+    expect(formatSalary("500")).toBe("$500");
+  });
+
+  test("handles millions", () => {
+    expect(formatSalary("1000000")).toBe("$1,000,000");
+  });
+
+  test("strips non-digit characters and reformats", () => {
+    expect(formatSalary("abc123def456")).toBe("$123,456");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(formatSalary("")).toBe("");
+  });
+
+  test("returns empty string for input with no digits", () => {
+    expect(formatSalary("$,,")).toBe("");
+  });
+});
+
+describe("parseSalaryToStorageFormat", () => {
+  test("converts plain number to formatted string", () => {
+    expect(parseSalaryToStorageFormat("100000")).toBe("$100,000");
+  });
+
+  test("normalizes already-formatted salary", () => {
+    expect(parseSalaryToStorageFormat("$100,000")).toBe("$100,000");
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseSalaryToStorageFormat("")).toBeNull();
+  });
+
+  test("returns null for string with no digits", () => {
+    expect(parseSalaryToStorageFormat("$,,")).toBeNull();
+  });
+
+  test("strips non-digit chars and formats", () => {
+    expect(parseSalaryToStorageFormat("$85k")).toBe("$85");
   });
 });

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -1,4 +1,4 @@
-import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS, formatSalary, parseSalaryToStorageFormat } from "@shared/schema";
 
 export function getNextStatus(currentStatus: string): string {
   const terminalStatuses = ["Offer", "Rejected", "Withdrawn"];
@@ -36,6 +36,14 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
   if (data.interestLevel !== undefined) {
     if (!INTEREST_LEVELS.includes(data.interestLevel as (typeof INTEREST_LEVELS)[number])) {
       errors.push(`Interest level must be one of: ${INTEREST_LEVELS.join(", ")}`);
+    }
+  }
+
+  if (data.salary !== undefined && data.salary !== null && data.salary !== "") {
+    const salaryStr = String(data.salary);
+    const digits = salaryStr.replace(/[^0-9]/g, "");
+    if (!digits) {
+      errors.push("Salary must contain at least one digit");
     }
   }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -38,6 +38,7 @@ export async function registerRoutes(
     if (body.companyName !== undefined) updates.companyName = body.companyName;
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
+    if (body.salary !== undefined) updates.salary = body.salary;
     if (body.notes !== undefined) updates.notes = body.notes;
 
     if (body.status !== undefined) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -21,9 +21,22 @@ export const prospects = pgTable("prospects", {
   jobUrl: text("job_url"),
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
+  salary: text("salary"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
+
+export function formatSalary(value: string): string {
+  const digits = value.replace(/[^0-9]/g, "");
+  if (!digits) return "";
+  return "$" + digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+export function parseSalaryToStorageFormat(value: string): string | null {
+  const digits = value.replace(/[^0-9]/g, "");
+  if (!digits) return null;
+  return "$" + digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
 
 export const insertProspectSchema = createInsertSchema(prospects).omit({
   id: true,
@@ -34,6 +47,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
+  salary: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
 });
 


### PR DESCRIPTION
Introduce a nullable 'salary' text column to the 'prospects' table. Implement 'formatSalary' and 'parseSalaryToStorageFormat' helper functions in '@shared/schema' for consistent currency formatting ($X,XXX). Update the Add and Edit Prospect forms to include a new "Target Salary" input field with live formatting. The Prospect Card now displays the salary in green with a dollar icon when present, and the backend PATCH route handles salary updates with validation. Comprehensive tests are added for validation, formatting helpers, and edge cases.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 46ce579c-888d-4b2e-a11d-810954ccee55
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: a6fcae57-899d-4fc8-9f2f-ab002b234749
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/cd3b55b1-1334-4238-8147-fc5afe9b503e/46ce579c-888d-4b2e-a11d-810954ccee55/s9NICbf
Replit-Helium-Checkpoint-Created: true