### PR TITLE
Add coffee chat filter and toggle to the applied prospects list

### DIFF
--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign, Coffee } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -41,9 +41,23 @@ function InterestIndicator({ level }: { level: string }) {
   }
 }
 
-export function ProspectCard({ prospect }: { prospect: Prospect }) {
+export function ProspectCard({ prospect, showCoffeeChat }: { prospect: Prospect; showCoffeeChat?: boolean }) {
   const { toast } = useToast();
   const [editOpen, setEditOpen] = useState(false);
+
+  const coffeeChatMutation = useMutation({
+    mutationFn: async () => {
+      await apiRequest("PATCH", `/api/prospects/${prospect.id}`, {
+        coffeeChat: !prospect.coffeeChat,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prospects"] });
+    },
+    onError: () => {
+      toast({ title: "Failed to update coffee chat", variant: "destructive" });
+    },
+  });
 
   const deleteMutation = useMutation({
     mutationFn: async () => {
@@ -105,6 +119,24 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {showCoffeeChat && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                coffeeChatMutation.mutate();
+              }}
+              disabled={coffeeChatMutation.isPending}
+              className={`inline-flex items-center gap-1 text-xs font-medium rounded-full px-2 py-0.5 transition-colors ${
+                prospect.coffeeChat
+                  ? "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400"
+                  : "bg-muted text-muted-foreground hover:bg-muted-foreground/10"
+              }`}
+              data-testid={`button-coffee-chat-${prospect.id}`}
+            >
+              <Coffee className="w-3 h-3" />
+              {prospect.coffeeChat ? "Coffee Chat" : "No Coffee Chat"}
+            </button>
+          )}
         </div>
 
         {prospect.salary && (

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -17,12 +17,19 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 
 type InterestFilter = "All" | typeof INTEREST_LEVELS[number];
+type CoffeeChatFilter = "All" | "Yes" | "No";
 
 const FILTER_OPTIONS: { value: InterestFilter; label: string }[] = [
   { value: "All", label: "All" },
   { value: "High", label: "🔥 High" },
   { value: "Medium", label: "👍 Medium" },
   { value: "Low", label: "🤷 Low" },
+];
+
+const COFFEE_CHAT_FILTER_OPTIONS: { value: CoffeeChatFilter; label: string }[] = [
+  { value: "All", label: "All" },
+  { value: "Yes", label: "Yes" },
+  { value: "No", label: "No" },
 ];
 
 const columnColors: Record<string, string> = {
@@ -45,12 +52,20 @@ function KanbanColumn({
   isLoading: boolean;
 }) {
   const [filter, setFilter] = useState<InterestFilter>("All");
+  const [coffeeChatFilter, setCoffeeChatFilter] = useState<CoffeeChatFilter>("All");
   const statusSlug = status.replace(/\s+/g, "-").toLowerCase();
+  const isApplied = status === "Applied";
 
-  const filteredProspects =
+  let filteredProspects =
     filter === "All"
       ? prospects
       : prospects.filter((p) => p.interestLevel === filter);
+
+  if (isApplied && coffeeChatFilter !== "All") {
+    filteredProspects = filteredProspects.filter((p) =>
+      coffeeChatFilter === "Yes" ? p.coffeeChat : !p.coffeeChat
+    );
+  }
 
   return (
     <div
@@ -85,6 +100,25 @@ function KanbanColumn({
           </button>
         ))}
       </div>
+      {isApplied && (
+        <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border/30">
+          <span className="text-[10px] text-muted-foreground font-medium mr-1 whitespace-nowrap">Coffee Chat</span>
+          {COFFEE_CHAT_FILTER_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setCoffeeChatFilter(opt.value)}
+              className={`px-2 py-0.5 text-[11px] rounded-full transition-colors whitespace-nowrap ${
+                coffeeChatFilter === opt.value
+                  ? "bg-primary text-primary-foreground font-medium"
+                  : "bg-muted hover:bg-muted-foreground/10 text-muted-foreground"
+              }`}
+              data-testid={`filter-coffee-${opt.value.toLowerCase()}-${statusSlug}`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
           {isLoading ? (
@@ -100,7 +134,7 @@ function KanbanColumn({
             </div>
           ) : (
             filteredProspects.map((prospect) => (
-              <ProspectCard key={prospect.id} prospect={prospect} />
+              <ProspectCard key={prospect.id} prospect={prospect} showCoffeeChat={isApplied} />
             ))
           )}
         </div>

--- a/replit.md
+++ b/replit.md
@@ -30,7 +30,7 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, coffee_chat, notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -75,6 +75,60 @@ describe("prospect creation validation", () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("Salary must contain at least one digit");
   });
+
+  test("accepts coffeeChat as true", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      coffeeChat: true,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts coffeeChat as false", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      coffeeChat: false,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts prospect without coffeeChat field", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts coffeeChat as null", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      coffeeChat: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects coffeeChat as non-boolean", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      coffeeChat: "yes" as unknown,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Coffee chat must be a boolean value");
+  });
 });
 
 describe("formatSalary", () => {

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -47,6 +47,12 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.coffeeChat !== undefined && data.coffeeChat !== null) {
+    if (typeof data.coffeeChat !== "boolean") {
+      errors.push("Coffee chat must be a boolean value");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,6 +39,7 @@ export async function registerRoutes(
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.salary !== undefined) updates.salary = body.salary;
+    if (body.coffeeChat !== undefined) updates.coffeeChat = body.coffeeChat;
     if (body.notes !== undefined) updates.notes = body.notes;
 
     if (body.status !== undefined) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, boolean } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -22,6 +22,7 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   salary: text("salary"),
+  coffeeChat: boolean("coffee_chat").default(false),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -48,6 +49,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
   salary: z.string().optional().nullable(),
+  coffeeChat: z.boolean().optional().default(false),
   notes: z.string().optional().nullable(),
 });
 


### PR DESCRIPTION
Adds a boolean `coffeeChat` column to the `prospects` table, a toggle button to individual prospect cards in the "Applied" column, and a new filter to the "Applied" column to sort by coffee chat status. Includes validation and tests for the new field.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 46ce579c-888d-4b2e-a11d-810954ccee55
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: fab805eb-688f-4c42-8692-617db06ee69a
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/cd3b55b1-1334-4238-8147-fc5afe9b503e/46ce579c-888d-4b2e-a11d-810954ccee55/Ibcta2R
Replit-Helium-Checkpoint-Created: true